### PR TITLE
Modify Simulacion iteration logging

### DIFF
--- a/Back-end/plg/src/main/java/com/plg/utils/Simulacion.java
+++ b/Back-end/plg/src/main/java/com/plg/utils/Simulacion.java
@@ -201,16 +201,16 @@ public class Simulacion {
             System.out.println("📅 Fecha de inicio (desde frontend): " + fechaActual);
             System.out.println("📦 Pedidos semanales iniciales: " + pedidosSemanal.size());
             // ! ACA SE SIMULA LA SEMANA COMPLETA
+            int contadorIteraciones = 0;
 
             while (!simulacionTerminadaporelfront) {
                 // ! ACA SE SIMULA LA SEMANA COMPLETA
                 // !TAMAÑO DE PEDIDPOS SEMANALES fecha actual y fecha limite
-                int contadorIteraciones = 0;
+                contadorIteraciones++;
                 if (contadorIteraciones <= 1 && pedidosSemanal.size() > 0) {
                     System.out.println("Tamaño de pedidos semanales: " + pedidosSemanal.size());
                     System.out.println("Fecha actual: " + fechaActual);
                     System.out.println("Fecha limite: " + fechaLimite);
-                    contadorIteraciones++;
                 }
 
                 while (!pedidosSemanal.isEmpty()


### PR DESCRIPTION
## Summary
- ensure simulation prints sizes and dates only once by using an iteration counter outside the loop

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686edc4f95d4832dae104446a13c456f