### PR TITLE
Fix comment about pause duration

### DIFF
--- a/Back-end/plg/src/main/java/com/plg/utils/Simulacion.java
+++ b/Back-end/plg/src/main/java/com/plg/utils/Simulacion.java
@@ -219,7 +219,7 @@ public class Simulacion {
                     while (GestorHistorialSimulacion.isPausada() || isFaltaCrearParche()) {
                         try {
                             System.out.println("⏸️ Simulación pausada, esperando...");
-                            Thread.sleep(10000); // Esperar 100ms antes de verificar de nuevo
+                            Thread.sleep(10000); // Esperar 10s antes de verificar de nuevo
 
                         } catch (InterruptedException e) {
                             Thread.currentThread().interrupt();


### PR DESCRIPTION
## Summary
- clarify that the pause inside `Simulacion` is 10 seconds

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686edc501a2c832d8de2f34a732e4a90